### PR TITLE
Enable reading security status for T234

### DIFF
--- a/tegra-fuse-tool.c
+++ b/tegra-fuse-tool.c
@@ -90,24 +90,13 @@ show_sec_config_status (tegra_fusectx_t ctx)
 {
 	uint32_t secmode;
 	tegra_soctype_t soc;
-	tegra_fuse_t fuse_id;
 	
 	if (tegra_fuse_soctype(ctx, &soc) < 0) {
 		fprintf(stderr, "ERR: could not identify SoC type\n");
 		return 1;
 	}
 
-	if (soc != TEGRA_SOCTYPE_234) {
-		fprintf(stderr, "ERR: Unsupported SOC\n");
-		return 1;
-	}
-
-	if (tegra_fuse_id(ctx, "security_mode", &fuse_id) < 0) {
-		fprintf(stderr, "ERR: unrecognized fuse name: security_mode\n");
-		return 1;
-	}
-
-	if (tegra_fuse_read(ctx, fuse_id, &secmode, sizeof(secmode)) < 0) {
+	if (tegra_fuse_read(ctx, TEGRA_FUSE_SECURITY_MODE, &secmode, sizeof(secmode)) < 0) {
 		fprintf(stderr, "ERR: could not read security mode fuse\n");
 		return 1;
 	}

--- a/tegra-fuse-tool.c
+++ b/tegra-fuse-tool.c
@@ -90,19 +90,28 @@ show_sec_config_status (tegra_fusectx_t ctx)
 {
 	uint32_t secmode;
 	tegra_soctype_t soc;
-
+	tegra_fuse_t fuse_id;
+	
 	if (tegra_fuse_soctype(ctx, &soc) < 0) {
 		fprintf(stderr, "ERR: could not identify SoC type\n");
 		return 1;
 	}
-	if (soc == TEGRA_SOCTYPE_234) {
-		fprintf(stderr, "ERR: not supported on T234\n");
+
+	if (soc != TEGRA_SOCTYPE_234) {
+		fprintf(stderr, "ERR: Unsupported SOC\n");
 		return 1;
 	}
-	if (tegra_fuse_read(ctx, TEGRA_FUSE_SECURITY_MODE, &secmode, sizeof(secmode)) < 0) {
-		fprintf(stderr, "Error reading security mode fuse\n");
+
+	if (tegra_fuse_id(ctx, "security_mode", &fuse_id) < 0) {
+		fprintf(stderr, "ERR: unrecognized fuse name: security_mode\n");
 		return 1;
 	}
+
+	if (tegra_fuse_read(ctx, fuse_id, &secmode, sizeof(secmode)) < 0) {
+		fprintf(stderr, "ERR: could not read security mode fuse\n");
+		return 1;
+	}
+
 	printf("%s\n", (secmode == 0 ? "OPEN" : "CLOSED"));
 	return 0;
 


### PR DESCRIPTION
This PR refactors the security mode detection functionality to properly support the T234 SoC (previously unsupported) and improves the fuse reading mechanism by using named fuse identifiers instead of hardcoded constants. I have enabled this only for Orin as I cannot test this on Thor. 

1. Changed the SoC check from rejecting T234 (if (soc == TEGRA_SOCTYPE_234)) to requiring T234 (if (soc != TEGRA_SOCTYPE_234)). 
2. Replaced direct use of TEGRA_FUSE_SECURITY_MODE constant with a named fuse identifier lookup via tegra_fuse_id()
3. Updated error messages to be more descriptive (e.g., "ERR: Unsupported SOC", "ERR: could not read security mode fuse")

Users can now query the security mode (OPEN/CLOSED) on T234 devices

Test Notes:
Tested on orin AGX/NX